### PR TITLE
Add share button with URL state synchronization

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -31,13 +31,16 @@
 		"three-3mf-exporter": "^0.0.4",
 		"three-stdlib": "^2.35.2",
 		"urql": "^4.2.1",
-		"zustand": "^5.0.5"
+		"zustand": "^5.0.5",
+		"zod": "^4.1.5",
+		"lz-string": "^1.5.0"
 	},
 	"devDependencies": {
 		"@octokit/graphql-schema": "^15.25.0",
 		"@rsbuild/core": "^1.3.22",
 		"@rsbuild/plugin-react": "^1.3.2",
 		"@tanstack/router-plugin": "^1.129.8",
+		"@types/lz-string": "^1.5.0",
 		"@types/opentype.js": "^1.3.8",
 		"@types/react": "^18.3.1",
 		"@types/react-dom": "^18.3.1",

--- a/packages/app/src/components/appshell.tsx
+++ b/packages/app/src/components/appshell.tsx
@@ -7,6 +7,7 @@ import { Skyline } from "../three/skyline";
 import { HoverCard } from "./hover_card";
 import { Sidebar } from "./sidebar";
 import { SkylineControls } from "./skyline_controls";
+import { useUrlStateSync } from "../hooks/useUrlState";
 
 export interface EditorAppShellProps {
 	profile: UserProfile | null;
@@ -25,6 +26,8 @@ export function EditorAppShell({ profile }: EditorAppShellProps) {
 		start,
 		end,
 	});
+
+	useUrlStateSync();
 
 	return (
 		<AppShell

--- a/packages/app/src/components/appshell.tsx
+++ b/packages/app/src/components/appshell.tsx
@@ -2,12 +2,12 @@ import { AppShell, LoadingOverlay } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import type { UserProfile } from "../api/auth";
 import { useExtendedQuery } from "../hooks/useExtendedQuery";
+import { useUrlStateSync } from "../hooks/useUrlState";
 import { useParametersContext } from "../stores/parameters";
 import { Skyline } from "../three/skyline";
 import { HoverCard } from "./hover_card";
 import { Sidebar } from "./sidebar";
 import { SkylineControls } from "./skyline_controls";
-import { useUrlStateSync } from "../hooks/useUrlState";
 
 export interface EditorAppShellProps {
 	profile: UserProfile | null;

--- a/packages/app/src/components/sidebar.tsx
+++ b/packages/app/src/components/sidebar.tsx
@@ -4,6 +4,7 @@ import {
 	Button,
 	Card,
 	Divider,
+	Group,
 	ScrollArea,
 	Stack,
 	Title,
@@ -28,6 +29,7 @@ import { GenerateSection } from "./sidebar_inputs/generate_section";
 import { InsetTextCheckbox } from "./sidebar_inputs/inset_text";
 import { RenderColorInput } from "./sidebar_inputs/render_color";
 import { ScaleInput } from "./sidebar_inputs/scale";
+import { ShareButton } from "./sidebar_inputs/share";
 import { TowerDampeningInput } from "./sidebar_inputs/tower_dampening";
 import { UsernameOverrideInput } from "./sidebar_inputs/username_override";
 
@@ -109,7 +111,10 @@ export function Sidebar(props: SidebarProps) {
 					</Stack>
 				</AppShell.Section>
 				<AppShell.Section>
-					<ExportButton />
+					<Group gap="xs">
+						<ShareButton />
+						<ExportButton />
+					</Group>
 				</AppShell.Section>
 			</Card>
 			<AppShell.Section>

--- a/packages/app/src/components/sidebar_inputs/export.tsx
+++ b/packages/app/src/components/sidebar_inputs/export.tsx
@@ -22,7 +22,7 @@ export function ExportButton() {
 	return (
 		<Suspense>
 			<Button
-				fullWidth
+				flex={1}
 				loading={model === null || dirty || exporting}
 				disabled={model === null || dirty || exporting}
 				component="a"

--- a/packages/app/src/components/sidebar_inputs/generate_section.tsx
+++ b/packages/app/src/components/sidebar_inputs/generate_section.tsx
@@ -15,13 +15,14 @@ export interface GenerateSectionProps {
 const MIN_START_YEAR = 2000;
 
 export function GenerateSection(props: GenerateSectionProps) {
-	const { ok, login } = props;
+	const { ok } = props;
 	const initialStartYear =
 		getParametersStore().getInitialState().inputs.startYear;
 	const initialEndYear = getParametersStore().getInitialState().inputs.endYear;
 	const setInputs = useParametersContext((state) => state.setInputs);
+	const nameFromStore = useParametersContext((state) => state.inputs.name);
 
-	const [name, setName] = useState(login ?? "");
+	const [name, setName] = useState(nameFromStore);
 	const [modified, setModified] = useState(false);
 
 	const [
@@ -59,6 +60,10 @@ export function GenerateSection(props: GenerateSectionProps) {
 	useEffect(() => {
 		setModified(false);
 	}, [ok]);
+
+	useEffect(() => {
+		setName(nameFromStore);
+	}, [nameFromStore]);
 
 	useEffect(() => {
 		if (!ok) {

--- a/packages/app/src/components/sidebar_inputs/share.tsx
+++ b/packages/app/src/components/sidebar_inputs/share.tsx
@@ -1,0 +1,90 @@
+import {
+	ActionIcon,
+	Button,
+	CopyButton,
+	Group,
+	Popover,
+	Stack,
+	Text,
+	Tooltip,
+} from "@mantine/core";
+import { IconCheck, IconCopy, IconShare2 } from "@tabler/icons-react";
+import { useEffect, useState } from "react";
+import { buildShareLinks } from "../../share/urlShare";
+import { useParametersContext } from "../../stores/parameters";
+
+export function ShareButton() {
+	const [opened, setOpened] = useState(false);
+	const inputs = useParametersContext((s) => s.inputs);
+	const [minimal, setMinimal] = useState<string>("");
+	const [full, setFull] = useState<string>("");
+
+	useEffect(() => {
+		if (!opened) return;
+		const { minimal, full } = buildShareLinks(inputs);
+		setMinimal(minimal);
+		setFull(full);
+	}, [opened, inputs]);
+
+	return (
+		<Popover opened={opened} onChange={setOpened} position="top" withArrow>
+			<Popover.Target>
+				<Button
+					variant="light"
+					onClick={() => setOpened((v) => !v)}
+					leftSection={<IconShare2 size={16} />}
+				>
+					<Text fw={900} size="sm">
+						Share
+					</Text>
+				</Button>
+			</Popover.Target>
+			<Popover.Dropdown>
+				<Stack gap={8} w={280}>
+					<Text size="sm" fw={600}>
+						Share options
+					</Text>
+					<Group gap="xs" wrap="nowrap">
+						<Text size="xs" style={{ flex: 1 }}>
+							Username + year range
+						</Text>
+						<CopyButton value={minimal} timeout={2000}>
+							{({ copied, copy }) => (
+								<Tooltip label={copied ? "Copied" : "Copy link"} withArrow>
+									<ActionIcon
+										onClick={copy}
+										variant="subtle"
+										color={copied ? "teal" : "gray"}
+									>
+										{copied ? <IconCheck size={16} /> : <IconCopy size={16} />}
+									</ActionIcon>
+								</Tooltip>
+							)}
+						</CopyButton>
+					</Group>
+					<Group gap="xs" wrap="nowrap">
+						<Text size="xs" style={{ flex: 1 }}>
+							Username + years + model/render
+						</Text>
+						<CopyButton value={full} timeout={2000}>
+							{({ copied, copy }) => (
+								<Tooltip label={copied ? "Copied" : "Copy link"} withArrow>
+									<ActionIcon
+										onClick={copy}
+										variant="subtle"
+										color={copied ? "teal" : "gray"}
+									>
+										{copied ? <IconCheck size={16} /> : <IconCopy size={16} />}
+									</ActionIcon>
+								</Tooltip>
+							)}
+						</CopyButton>
+					</Group>
+					<Text size="xs" c="dimmed">
+						Fonts are not yet included in shared links.
+					</Text>
+				</Stack>
+			</Popover.Dropdown>
+		</Popover>
+	);
+}

--- a/packages/app/src/hooks/useUrlState.ts
+++ b/packages/app/src/hooks/useUrlState.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+import { useParametersContext } from "../stores/parameters";
+import {
+	URL_PARAM_KEY,
+	toFull,
+	toMinimal,
+	encodeShareState,
+	getInitialInputsFromUrl,
+} from "../share/urlShare";
+
+export function useUrlStateSync() {
+	const inputs = useParametersContext((s) => s.inputs);
+	const setInputs = useParametersContext((s) => s.setInputs);
+
+	useEffect(() => {
+		const initial = getInitialInputsFromUrl(window.location.href);
+		if (Object.keys(initial).length) {
+			setInputs(initial);
+		}
+	}, []);
+
+	const prevEncodedRef = useRef<string | null>(null);
+	useEffect(() => {
+		const full = toFull(inputs);
+		const encoded = encodeShareState(full);
+		if (prevEncodedRef.current === encoded) return;
+		prevEncodedRef.current = encoded;
+		const url = new URL(window.location.href);
+		url.searchParams.set(URL_PARAM_KEY, encoded);
+		window.history.replaceState({}, "", url);
+	}, [inputs]);
+
+	return {
+		getMinimalLink: () => {
+			const minimal = toMinimal(inputs);
+			const encoded = encodeShareState(minimal);
+			const url = new URL(window.location.href);
+			url.searchParams.set(URL_PARAM_KEY, encoded);
+			return url.toString();
+		},
+		getFullLink: () => {
+			const full = toFull(inputs);
+			const encoded = encodeShareState(full);
+			const url = new URL(window.location.href);
+			url.searchParams.set(URL_PARAM_KEY, encoded);
+			return url.toString();
+		},
+	};
+}

--- a/packages/app/src/hooks/useUrlState.ts
+++ b/packages/app/src/hooks/useUrlState.ts
@@ -1,12 +1,12 @@
 import { useEffect, useRef } from "react";
-import { useParametersContext } from "../stores/parameters";
 import {
-	URL_PARAM_KEY,
-	toFull,
-	toMinimal,
 	encodeShareState,
 	getInitialInputsFromUrl,
+	toFull,
+	toMinimal,
+	URL_PARAM_KEY,
 } from "../share/urlShare";
+import { useParametersContext } from "../stores/parameters";
 
 export function useUrlStateSync() {
 	const inputs = useParametersContext((s) => s.inputs);

--- a/packages/app/src/routes/index.tsx
+++ b/packages/app/src/routes/index.tsx
@@ -4,8 +4,8 @@ import { fetchProfile, isAuthenticated } from "../api/auth";
 import { EditorAppShell } from "../components/appshell";
 import { createParametersStore, ParametersContext } from "../stores/parameters";
 import "../styles/editor.css";
-import { preloadDefaultFonts } from "../stores/fonts";
 import { getInitialInputsFromUrl } from "../share/urlShare";
+import { preloadDefaultFonts } from "../stores/fonts";
 
 export const Route = createFileRoute("/")({
 	component: Editor,

--- a/packages/app/src/routes/index.tsx
+++ b/packages/app/src/routes/index.tsx
@@ -5,6 +5,7 @@ import { EditorAppShell } from "../components/appshell";
 import { createParametersStore, ParametersContext } from "../stores/parameters";
 import "../styles/editor.css";
 import { preloadDefaultFonts } from "../stores/fonts";
+import { getInitialInputsFromUrl } from "../share/urlShare";
 
 export const Route = createFileRoute("/")({
 	component: Editor,
@@ -28,8 +29,9 @@ export const Route = createFileRoute("/")({
 
 export function Editor() {
 	const profile = Route.useLoaderData();
+	const initialFromUrl = getInitialInputsFromUrl(window.location.href);
 	const store = useRef(
-		createParametersStore({ name: profile?.login ?? "" }),
+		createParametersStore({ name: profile?.login ?? "", ...initialFromUrl }),
 	).current;
 
 	return (

--- a/packages/app/src/share/urlShare.ts
+++ b/packages/app/src/share/urlShare.ts
@@ -1,0 +1,158 @@
+import {
+	compressToEncodedURIComponent,
+	decompressFromEncodedURIComponent,
+} from "lz-string";
+import { z } from "zod";
+
+import type { SkylineModelInputParameters } from "../stores/parameters";
+import { ExportFormat } from "../three/export";
+import { SkylineBaseShape } from "../three/types";
+
+export const URL_PARAM_KEY = "s";
+
+export const MinimalShareSchema = z.object({
+	v: z.literal(1),
+	type: z.literal("minimal"),
+	name: z.string(),
+	startYear: z.number().int(),
+	endYear: z.number().int(),
+});
+
+export const FullShareSchema = z.object({
+	v: z.literal(1),
+	type: z.literal("full"),
+	name: z.string(),
+	nameOverride: z.string(),
+	startYear: z.number().int(),
+	endYear: z.number().int(),
+	insetText: z.boolean(),
+	towerSize: z.number(),
+	dampening: z.number(),
+	shape: z.nativeEnum(SkylineBaseShape),
+	padding: z.number(),
+	textDepth: z.number(),
+	color: z.string(),
+	showContributionColor: z.boolean(),
+	scale: z.number(),
+	exportFormat: z.nativeEnum(ExportFormat),
+	logoOffset: z.number(),
+	nameOffset: z.number(),
+	yearOffset: z.number(),
+});
+
+export const ShareSchema = z.union([MinimalShareSchema, FullShareSchema]);
+export type ShareState = z.infer<typeof ShareSchema>;
+
+export function toMinimal(inputs: SkylineModelInputParameters): ShareState {
+	return {
+		v: 1,
+		type: "minimal",
+		name: inputs.name,
+		startYear: inputs.startYear,
+		endYear: inputs.endYear,
+	};
+}
+
+export function toFull(inputs: SkylineModelInputParameters): ShareState {
+	return {
+		v: 1,
+		type: "full",
+		name: inputs.name,
+		nameOverride: inputs.nameOverride,
+		startYear: inputs.startYear,
+		endYear: inputs.endYear,
+		insetText: inputs.insetText,
+		towerSize: inputs.towerSize,
+		dampening: inputs.dampening,
+		shape: inputs.shape,
+		padding: inputs.padding,
+		textDepth: inputs.textDepth,
+		color: inputs.color,
+		showContributionColor: inputs.showContributionColor,
+		scale: inputs.scale,
+		exportFormat: inputs.exportFormat,
+		logoOffset: inputs.logoOffset,
+		nameOffset: inputs.nameOffset,
+		yearOffset: inputs.yearOffset,
+	};
+}
+
+export function encodeShareState(state: ShareState): string {
+	const json = JSON.stringify(state);
+	return compressToEncodedURIComponent(json);
+}
+
+export function decodeShareState(encoded: string): ShareState | null {
+	try {
+		const json = decompressFromEncodedURIComponent(encoded);
+		if (!json) return null;
+		const parsed = JSON.parse(json);
+		const result = ShareSchema.safeParse(parsed);
+		if (!result.success) return null;
+		return result.data;
+	} catch {
+		return null;
+	}
+}
+
+export function readShareFromUrl(urlString: string): ShareState | null {
+	try {
+		const url = new URL(urlString);
+		const encoded = url.searchParams.get(URL_PARAM_KEY);
+		if (!encoded) return null;
+		return decodeShareState(encoded);
+	} catch {
+		return null;
+	}
+}
+
+export function getInitialInputsFromUrl(
+	urlString: string,
+): Partial<SkylineModelInputParameters> {
+	const data = readShareFromUrl(urlString);
+	if (!data) return {};
+	if (data.type === "minimal") {
+		return {
+			name: data.name,
+			startYear: data.startYear,
+			endYear: data.endYear,
+		};
+	}
+	return {
+		name: data.name,
+		nameOverride: data.nameOverride,
+		startYear: data.startYear,
+		endYear: data.endYear,
+		insetText: data.insetText,
+		towerSize: data.towerSize,
+		dampening: data.dampening,
+		shape: data.shape,
+		padding: data.padding,
+		textDepth: data.textDepth,
+		color: data.color,
+		showContributionColor: data.showContributionColor,
+		scale: data.scale,
+		exportFormat: data.exportFormat,
+		logoOffset: data.logoOffset,
+		nameOffset: data.nameOffset,
+		yearOffset: data.yearOffset,
+	};
+}
+
+export function buildShareLinks(
+	inputs: SkylineModelInputParameters,
+	href?: string,
+): { minimal: string; full: string } {
+	const minimalState = toMinimal(inputs);
+	const fullState = toFull(inputs);
+	const minEnc = encodeShareState(minimalState);
+	const fullEnc = encodeShareState(fullState);
+	const base = new URL(href ?? window.location.href);
+	const url1 = new URL(base.toString());
+	url1.searchParams.set(URL_PARAM_KEY, minEnc);
+	const minimal = url1.toString();
+	const url2 = new URL(base.toString());
+	url2.searchParams.set(URL_PARAM_KEY, fullEnc);
+	const full = url2.toString();
+	return { minimal, full };
+}

--- a/packages/app/src/three/export.ts
+++ b/packages/app/src/three/export.ts
@@ -35,24 +35,24 @@ const prepareModel = (model: Group, scale: number) => {
 	const exportGroup = preparedModel.getObjectByName(
 		SkylineObjectNames.TowersExportGroup,
 	) as Group;
-	const instances = preparedModel.getObjectByName(
-		SkylineObjectNames.Towers,
-	) as InstancedMesh | undefined;
+	const instances = preparedModel.getObjectByName(SkylineObjectNames.Towers) as
+		| InstancedMesh
+		| undefined;
 
-    if (instances !== undefined) {
-        const meshes = createMeshesFromInstancedMesh(instances);
-    
-        meshes.position.set(0, meshes.position.y, 0);
-        meshes.updateMatrix();
-    
-        exportGroup.add(meshes);
-    
-        const instancesGroup = preparedModel.getObjectByName(
-            SkylineObjectNames.TowersParent,
-        ) as Group;
-        instancesGroup.removeFromParent();
-        instances.removeFromParent();
-    }
+	if (instances !== undefined) {
+		const meshes = createMeshesFromInstancedMesh(instances);
+
+		meshes.position.set(0, meshes.position.y, 0);
+		meshes.updateMatrix();
+
+		exportGroup.add(meshes);
+
+		const instancesGroup = preparedModel.getObjectByName(
+			SkylineObjectNames.TowersParent,
+		) as Group;
+		instancesGroup.removeFromParent();
+		instances.removeFromParent();
+	}
 
 	preparedModel.rotation.set(Math.PI / 2, 0, 0);
 	preparedModel.scale.set(scale, scale, scale);
@@ -72,7 +72,7 @@ const loader = async (
 	const preparedModel = prepareModel(model, scale);
 	const url = await EXPORT_MAP[format](preparedModel);
 	const vec = getThreeBoundingBox(preparedModel);
-	const size = `${Math.round(vec.x)}mm \u{00d7} ${Math.round(vec.y)}mm \u{00d7} ${Math.round(vec.z)}mm`;
+	const size = `${Math.round(vec.x)}\u{339c} \u{00d7} ${Math.round(vec.y)}\u{339c} \u{00d7} ${Math.round(vec.z)}\u{339c}`;
 	return { url, size };
 };
 
@@ -83,7 +83,9 @@ export function useExportedModel(
 ) {
 	const [downloadUrl, setDownloadUrl] = useState<string>("");
 	const [exporting, setExporting] = useState(true);
-	const [size, setSize] = useState("0mm \u{00d7} 0mm \u{00d7} 0mm");
+	const [size, setSize] = useState(
+		"0\u{339c} \u{00d7} 0\u{339c} \u{00d7} 0\u{339c}",
+	);
 	let exportTimeout: number | undefined;
 	const clearExportTimeout = () => {
 		if (exportTimeout !== undefined) {
@@ -100,7 +102,7 @@ export function useExportedModel(
 				}
 			})
 			.finally(() => {
-				exportTimeout = setTimeout(() => {
+				exportTimeout = window.setTimeout(() => {
 					setExporting(false);
 				}, 500);
 			});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       gql.tada:
         specifier: ^1.8.10
         version: 1.8.10(graphql@16.11.0)(typescript@5.8.3)
+      lz-string:
+        specifier: ^1.5.0
+        version: 1.5.0
       manifold-3d:
         specifier: ^3.2.1
         version: 3.2.1
@@ -80,6 +83,9 @@ importers:
       urql:
         specifier: ^4.2.1
         version: 4.2.2(@urql/core@5.1.1(graphql@16.11.0))(react@18.3.1)
+      zod:
+        specifier: ^4.1.5
+        version: 4.1.5
       zustand:
         specifier: ^5.0.5
         version: 5.0.5(@types/react@18.3.23)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))
@@ -96,6 +102,9 @@ importers:
       '@tanstack/router-plugin':
         specifier: ^1.129.8
         version: 1.129.8(@rsbuild/core@1.3.22)(@tanstack/react-router@1.129.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@types/lz-string':
+        specifier: ^1.5.0
+        version: 1.5.0
       '@types/opentype.js':
         specifier: ^1.3.8
         version: 1.3.8
@@ -1161,6 +1170,10 @@ packages:
   '@types/draco3d@1.4.10':
     resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
 
+  '@types/lz-string@1.5.0':
+    resolution: {integrity: sha512-s84fKOrzqqNCAPljhVyC5TjAo6BH4jKHw9NRNFNiRUY5QSgZCmVm5XILlWbisiKl+0OcS7eWihmKGS5akc2iQw==}
+    deprecated: This is a stub types definition. lz-string provides its own type definitions, so you do not need this installed.
+
   '@types/offscreencanvas@2019.7.3':
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
 
@@ -1572,6 +1585,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   maath@0.10.8:
     resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
@@ -2166,6 +2183,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.1.5:
+    resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
 
   zustand@3.7.2:
     resolution: {integrity: sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==}
@@ -3147,6 +3167,10 @@ snapshots:
 
   '@types/draco3d@1.4.10': {}
 
+  '@types/lz-string@1.5.0':
+    dependencies:
+      lz-string: 1.5.0
+
   '@types/offscreencanvas@2019.7.3': {}
 
   '@types/opentype.js@1.3.8': {}
@@ -3554,6 +3578,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   maath@0.10.8(@types/three@0.169.0)(three@0.169.0):
     dependencies:
@@ -4127,6 +4153,8 @@ snapshots:
   zod@3.22.3: {}
 
   zod@3.25.76: {}
+
+  zod@4.1.5: {}
 
   zustand@3.7.2(react@18.3.1):
     optionalDependencies:


### PR DESCRIPTION
Introduced a share button that opens a popover with options to share either the username and year range or the complete set of parameters including model and render settings. Implemented URL state synchronization to ensure the initial state is populated from the URL.

This does not include Font selection (if this is wanted, I rather not do it since @battlesquid seems to have something in mind that I don't know about).

Fixes #26